### PR TITLE
delete処理の単体テスト実装

### DIFF
--- a/src/main/java/com/example/schedule/demo/controller/ScheduleController.java
+++ b/src/main/java/com/example/schedule/demo/controller/ScheduleController.java
@@ -62,8 +62,8 @@ public class ScheduleController {
     }
 
     @DeleteMapping("schedules/delete/{id}")
-    public ResponseEntity<Map<String, String>> delete(@PathVariable Integer id, String title, LocalDate scheduleDate, LocalTime scheduleTime) {
-        scheduleService.delete(id, new Schedule(title, scheduleDate, scheduleTime));
+    public ResponseEntity<Map<String, String>> delete(@PathVariable Integer id) {
+        scheduleService.delete(id);
         Map<String, String> body = Map.of("massage", "delete success");
         return ResponseEntity.ok(body);
     }

--- a/src/main/java/com/example/schedule/demo/mapper/ScheduleMapper.java
+++ b/src/main/java/com/example/schedule/demo/mapper/ScheduleMapper.java
@@ -11,6 +11,8 @@ import org.apache.ibatis.annotations.Select;
 import org.apache.ibatis.annotations.Update;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,5 +33,5 @@ public interface ScheduleMapper {
     public void update(@Param("id") Integer id, @Param("schedule") Schedule schedule);
 
     @Delete("delete from schedules where id = #{id}")
-    public void delete(@Param("id") Integer id, @Param("schedule") Schedule schedule);
+    public void delete(@Param("id") Integer id);
 }

--- a/src/main/java/com/example/schedule/demo/service/ScheduleService.java
+++ b/src/main/java/com/example/schedule/demo/service/ScheduleService.java
@@ -20,5 +20,5 @@ public interface ScheduleService {
 
     Schedule updateSchedule(Integer id, Schedule schedule);
 
-    void delete(Integer id, Schedule schedule);
+    void delete(Integer id);
 }

--- a/src/main/java/com/example/schedule/demo/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/example/schedule/demo/service/ScheduleServiceImpl.java
@@ -53,10 +53,10 @@ public class ScheduleServiceImpl implements ScheduleService {
     }
 
     @Override
-    public void delete(Integer id, Schedule schedule) {
+    public void delete(Integer id) {
         Optional<Schedule> existingSchedule = this.scheduleMapper.findById(id);
         if (existingSchedule.isPresent()) {
-            scheduleMapper.delete(id, schedule);
+            scheduleMapper.delete(id);
         } else {
             throw new ScheduleNotFoundException("入力したidは存在しません");
         }

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -185,7 +185,6 @@ class ScheduleControllerTest {
 
     @Test
     void 指定したidでデータが削除できること() throws Exception {
-        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         doNothing().when(scheduleServiceImpl).delete(1);
 
         String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -210,7 +210,6 @@ class ScheduleControllerTest {
     @Test
     void 指定したidが存在しない場合例外を投げること() throws Exception {
         Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
-        Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100);
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100).contentType(MediaType.APPLICATION_JSON).content(

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -192,7 +192,7 @@ class ScheduleControllerTest {
     void 指定したidでデータが削除できること() throws Exception {
         Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
-        doNothing().when(scheduleServiceImpl).delete(1, deleteSchedule);
+        doNothing().when(scheduleServiceImpl).delete(1);
 
         String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(
                         """
@@ -217,7 +217,7 @@ class ScheduleControllerTest {
     void 指定したidが存在しない場合例外を投げること() throws Exception {
         Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
-        doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100, deleteSchedule);
+        doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100);
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100).contentType(MediaType.APPLICATION_JSON).content(
                         """

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -208,7 +208,6 @@ class ScheduleControllerTest {
 
     @Test
     void 指定したidが存在しない場合例外を投げること() throws Exception {
-        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100);
 
         mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100).contentType(MediaType.APPLICATION_JSON).content(

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -189,5 +189,31 @@ class ScheduleControllerTest {
 
         verify(scheduleServiceImpl).updateSchedule(100, updateScheduleTime);
     }
+
+
+    @Test
+    void 指定したidでデータが削除できること() throws Exception {
+        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        doNothing().when(scheduleServiceImpl).delete(1, deleteSchedule);
+
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(
+                        """
+                                {
+                                "id":1,
+                                "title":"歯医者",
+                                "scheduleDate":"2024-06-25",
+                                "scheduleTime":"14:00:00"
+                                }                               
+                                """
+                ))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+        JSONAssert.assertEquals("""
+                { 
+                "massage" : "delete success"
+                } 
+                """, response, JSONCompareMode.STRICT);
+    }
 }
 

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -49,6 +49,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,10 +65,6 @@ class ScheduleControllerTest {
 
     @MockBean
     ScheduleServiceImpl scheduleServiceImpl;
-
-    @Mock
-    ScheduleMapper scheduleMapper;
-
 
     @Test
     void findAllメソッドで全てのレコードを取得できる() throws Exception {
@@ -215,5 +212,27 @@ class ScheduleControllerTest {
                 } 
                 """, response, JSONCompareMode.STRICT);
     }
+
+    @Test
+    void 指定したidが存在しない場合例外を投げること() throws Exception {
+        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100, deleteSchedule);
+
+        mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100).contentType(MediaType.APPLICATION_JSON).content(
+                        """
+                                {
+                                "id":100,
+                                "title":"歯医者",
+                                "scheduleDate":"2024-06-25",
+                                "scheduleTime":"14:00:00"
+                                }     
+                                """
+                ))
+                .andExpect(status().is(404))
+                .equals(new ScheduleNotFoundException("入力したidは存在しません"));
+
+    }
+
 }
 

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -163,7 +163,6 @@ class ScheduleControllerTest {
 
     @Test
     void updateメソッドで存在しないidを指定した場合にScheduleNotFoundExceptionを投げること() throws Exception {
-        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         Schedule updateScheduleTime = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(16, 00));
         when(scheduleServiceImpl.updateSchedule(100, updateScheduleTime)).thenThrow(new ScheduleNotFoundException("入力したidは存在しません"));
 

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -185,8 +185,7 @@ class ScheduleControllerTest {
 
     @Test
     void 指定したidでデータが削除できること() throws Exception {
-        //Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
-        Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         doNothing().when(scheduleServiceImpl).delete(1);
 
         String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -135,12 +135,8 @@ class ScheduleControllerTest {
 
     @Test
     void 指定したidでデータが変更できること() throws Exception {
-        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         Schedule updateScheduleTime = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(16, 00));
-        when(scheduleServiceImpl.findById(1)).thenReturn(exsintingSchedule);
         Schedule schedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(16, 00));
-
-
         doReturn(schedule).when(scheduleServiceImpl).updateSchedule(1, updateScheduleTime);
 
         String response = mockMvc.perform(MockMvcRequestBuilders.put("/schedules/edit/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(
@@ -190,7 +186,7 @@ class ScheduleControllerTest {
 
     @Test
     void 指定したidでデータが削除できること() throws Exception {
-        Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
+        //Schedule exsintingSchedule = new Schedule(1, "歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         Schedule deleteSchedule = new Schedule("歯医者", LocalDate.of(2024, 06, 25), LocalTime.of(14, 00));
         doNothing().when(scheduleServiceImpl).delete(1);
 
@@ -233,6 +229,5 @@ class ScheduleControllerTest {
                 .equals(new ScheduleNotFoundException("入力したidは存在しません"));
 
     }
-
 }
 

--- a/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
+++ b/src/test/java/com/example/schedule/demo/controller/ScheduleControllerTest.java
@@ -187,16 +187,7 @@ class ScheduleControllerTest {
     void 指定したidでデータが削除できること() throws Exception {
         doNothing().when(scheduleServiceImpl).delete(1);
 
-        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1).contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                                {
-                                "id":1,
-                                "title":"歯医者",
-                                "scheduleDate":"2024-06-25",
-                                "scheduleTime":"14:00:00"
-                                }                               
-                                """
-                ))
+        String response = mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 1))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
         JSONAssert.assertEquals("""
@@ -210,16 +201,7 @@ class ScheduleControllerTest {
     void 指定したidが存在しない場合例外を投げること() throws Exception {
         doThrow(new ScheduleNotFoundException("入力したidは存在しません")).when(scheduleServiceImpl).delete(100);
 
-        mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100).contentType(MediaType.APPLICATION_JSON).content(
-                        """
-                                {
-                                "id":100,
-                                "title":"歯医者",
-                                "scheduleDate":"2024-06-25",
-                                "scheduleTime":"14:00:00"
-                                }     
-                                """
-                ))
+        mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/{id}", 100))
                 .andExpect(status().is(404))
                 .equals(new ScheduleNotFoundException("入力したidは存在しません"));
 

--- a/src/test/java/com/example/schedule/demo/service/ScheduleServiceImplTest.java
+++ b/src/test/java/com/example/schedule/demo/service/ScheduleServiceImplTest.java
@@ -108,10 +108,10 @@ class ScheduleServiceImplTest {
     void 指定したidが存在した場合そのidと情報を削除する() throws ScheduleNotFoundException {
         Schedule existingSchedule = new Schedule(1, "予防接種", LocalDate.of(2024, 11, 15), LocalTime.of(14, 00));
         doReturn(Optional.of(existingSchedule)).when(scheduleMapper).findById(1);
-        doNothing().when(scheduleMapper).delete(1, existingSchedule);
+        doNothing().when(scheduleMapper).delete(1);
 
-        scheduleServiceImpl.delete(1, existingSchedule);
-        verify(scheduleMapper, times(1)).delete(1, existingSchedule);
+        scheduleServiceImpl.delete(1);
+        verify(scheduleMapper, times(1)).delete(1);
     }
 
     @Test
@@ -119,7 +119,7 @@ class ScheduleServiceImplTest {
         Schedule existingSchedule = new Schedule(1, "予防接種", LocalDate.of(2024, 11, 15), LocalTime.of(14, 00));
         when(scheduleMapper.findById(100)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> scheduleServiceImpl.delete(100, existingSchedule))
+        assertThatThrownBy(() -> scheduleServiceImpl.delete(100))
                 .isInstanceOfSatisfying(ScheduleNotFoundException.class, (e) -> {
                     assertThat(e.getMessage()).isEqualTo("入力したidは存在しません");
                 });


### PR DESCRIPTION
# Controllerクラスの単体テストに取り組んでいます。
## deleteリクエストの単体テストを以下の2点実装しました。
　※ deleteメソッドの引数も同時に修正したので変更箇所が見難い状態です・・。すみません。
　1.指定したidでデータが削除できるか
　2.指定したidが存在しない場合、例外を投げるか
　[コミットハッシュです](https://github.com/aokiayukodesu/Schedule-list/pull/15/commits/3e6d0ec5251e5a6c105fa02ecd5d498c8bf5e523)

  ご確認宜しくお願い致します。　
## 動作結果です
<img width="1440" alt="スクリーンショット 2024-05-02 7 57 39" src="https://github.com/aokiayukodesu/Schedule-list/assets/116893034/03ad1625-7204-4f10-b256-42b22c05b156">

