### PR TITLE
登録処理のDBテスト実装しました

### DIFF
--- a/src/test/Resources/datasets/addSchedules.yml
+++ b/src/test/Resources/datasets/addSchedules.yml
@@ -1,0 +1,14 @@
+schedules:
+  - id: 1
+    title: "親知らず"
+    scheduleDate: "2024-05-15"
+    scheduleTime: "10:00:00"
+  - id: 2
+    title: "ストレンジャーシングス新シーズン配信"
+    scheduleDate: "2024-05-27"
+    scheduleTime: "10:00:00"
+  - id: 3
+    title: "一時保育"
+    scheduleDate: "2024-05-21"
+    scheduleTime: "10:00:00"
+

--- a/src/test/java/com/example/schedule/demo/mapper/ScheduleMapperTest.java
+++ b/src/test/java/com/example/schedule/demo/mapper/ScheduleMapperTest.java
@@ -2,6 +2,7 @@ package com.example.schedule.demo.mapper;
 
 import com.example.schedule.demo.entity.Schedule;
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
 import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
@@ -53,6 +54,16 @@ class ScheduleMapperTest {
     void 存在しないidを指定した場合に空を返す() {
         Optional<Schedule> schedule = scheduleMapper.findById(100);
         assertThat(schedule).isEmpty();
+    }
+
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @ExpectedDataSet(value = "datasets/addSchedules.yml", ignoreCols = "id")
+    @Transactional
+    void 情報が登録されること() {
+        Schedule schedule = new Schedule("一時保育", LocalDate.of(2024, 05, 21),
+                LocalTime.of(10, 00, 00));
+        scheduleMapper.createTable(schedule);
     }
 }
 

--- a/src/test/java/com/example/schedule/demo/mapper/ScheduleMapperTest.java
+++ b/src/test/java/com/example/schedule/demo/mapper/ScheduleMapperTest.java
@@ -60,7 +60,7 @@ class ScheduleMapperTest {
     @DataSet(value = "datasets/schedules.yml")
     @ExpectedDataSet(value = "datasets/addSchedules.yml", ignoreCols = "id")
     @Transactional
-    void 情報が登録されること() {
+    void 予定名と予定日時の情報が登録されること() {
         Schedule schedule = new Schedule("一時保育", LocalDate.of(2024, 05, 21),
                 LocalTime.of(10, 00, 00));
         scheduleMapper.createTable(schedule);


### PR DESCRIPTION
### 登録処理のDBテスト実装しました
  スケジュールの予定名及び予定日時の３つの情報をMapperのcreateTableに渡すと登録されるかテストしました。
  ご確認宜しくお願い致します。

動作確認結果です。
<img width="1440" alt="スクリーンショット 2024-05-16 8 38 34" src="https://github.com/aokiayukodesu/Schedule-list/assets/116893034/95e8b0e1-c230-44c5-9e9a-a67ee4d9b43e">
