### PR TITLE
create処理の結合テストを実装

### DIFF
--- a/src/test/Resources/datasets/addSchedules.yml
+++ b/src/test/Resources/datasets/addSchedules.yml
@@ -9,6 +9,6 @@ schedules:
     scheduleTime: "10:00:00"
   - id: 3
     title: "一時保育"
-    scheduleDate: "2024-05-21"
+    scheduleDate: "2025-05-21"
     scheduleTime: "10:00:00"
 

--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -1,18 +1,23 @@
 package com.example.schedule.demo.integrationTest;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.spring.api.DBRider;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 
 
@@ -79,6 +84,29 @@ public class IntegrationTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("入力したidは存在しません"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/schedules/100"));
+    }
+
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @ExpectedDataSet(value = "datasets/addSchedules.yml", ignoreCols = "id")
+    @Transactional
+    void 新規で予定と予定日時を入力すると登録されること() throws Exception {
+        String requestBody = """
+                   {
+                   "title": "一時保育",
+                   "scheduleDate": "2025-05-21",
+                   "scheduleTime": "10:00:00"
+                   }                                                               
+                """;
+        mockMvc.perform(MockMvcRequestBuilders.post("/schedules")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        { 
+                        "massage" : "your date successfully created" 
+                        } 
+                        """));
     }
 
 }


### PR DESCRIPTION
## create処理の結合テストを実装
 新たに予定と予定日時を入力されると登録されるテストを実装しました。
 8ab60b77890738735275e753961be071250f7370

### 動作確認結果です
<img width="1440" alt="スクリーンショット 2024-07-11 7 58 17" src="https://github.com/aokiayukodesu/Schedule-list/assets/116893034/48005345-7717-42ba-9b63-30713cad9076">
