### PR TITLE
update処理の結合テストを実装

### DIFF
--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -109,5 +109,27 @@ public class IntegrationTest {
                         """));
     }
 
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @ExpectedDataSet(value = "datasets/updateSchedules.yml")
+    @Transactional
+    void 該当するIDの予定情報を更新する() throws Exception {
+        String requestBody = """
+                   {                
+                   "title": "親知らず",
+                   "scheduleDate": "2024-07-17",
+                   "scheduleTime": "13:00:00"
+                   }                                                               
+                """;
+        mockMvc.perform(MockMvcRequestBuilders.put("/schedules/edit/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        { 
+                        "massage" : "update ok" 
+                        } 
+                        """));
+    }
 }
 


### PR DESCRIPTION
## update処理の結合テストを実装
 該当するIDの予定情報を更新できるテストを実装しました。(ID1の日時を変更しました)
 ご確認宜しくお願い致します。
673489d5c69f437288e0bde8c6758a301dd28262

### 動作確認結果です
<img width="1440" alt="スクリーンショット 2024-07-12 7 38 00" src="https://github.com/user-attachments/assets/bf8bc3aa-0a86-415a-b52e-9c95605fb76a">
