### PR TITLE
updateリクエストで404エラーを返す結合テストを実装

### DIFF
--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -131,5 +131,26 @@ public class IntegrationTest {
                         } 
                         """));
     }
+
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @Transactional
+    void updateリクエストで指定したidが存在しない場合404エラーを返すこと() throws Exception {
+        String requestBody = """
+                {
+                "title": "親知らず",
+                "scheduleDate": "2024-07-17",
+                "scheduleTime": "13:00:00"
+                }
+                """;
+        mockMvc.perform(MockMvcRequestBuilders.put("/schedules/edit/100")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(MockMvcResultMatchers.status().is(404))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("入力したidは存在しません"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/schedules/edit/100"));
+    }
 }
 


### PR DESCRIPTION
## updateリクエストで404エラーを返す結合テストを実装しました
　存在しないidを指定し、updateリクエストを実行した場合404エラーを返すテストを実装しました。

afcdc5b4bf293b1bdc6633d810d4805153bdf409

### 実行結果です
<img width="1440" alt="スクリーンショット 2024-07-12 7 38 00" src="https://github.com/user-attachments/assets/7c34387e-85c2-471f-a37d-3a9eebe30cdc">

