### PR TITLE
deleteリクエストの結合テストを実装

### DIFF
--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -161,9 +161,9 @@ public class IntegrationTest {
         mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/1"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.content().json("""
-                        { 
-                        "massage" : "delete success" 
-                        } 
+                        {
+                          	"massage": "delete success"
+                        }
                         """));
     }
 

--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -166,5 +166,17 @@ public class IntegrationTest {
                         } 
                         """));
     }
+
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @Transactional
+    void deleteリクエストで指定したidが存在しない場合404エラーを返すこと() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/100"))
+                .andExpect(MockMvcResultMatchers.status().is(404))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.timestamp").exists())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.error").value("Not Found"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("入力したidは存在しません"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/schedules/delete/100"));
+    }
 }
 

--- a/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
+++ b/src/test/java/com/example/schedule/demo/integrationTest/IntegrationTest.java
@@ -152,5 +152,19 @@ public class IntegrationTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("入力したidは存在しません"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.path").value("/schedules/edit/100"));
     }
+
+    @Test
+    @DataSet(value = "datasets/schedules.yml")
+    @ExpectedDataSet(value = "datasets/deleteSchedules.yml")
+    @Transactional
+    void 該当するIDの予定情報を削除する() throws Exception {
+        mockMvc.perform(MockMvcRequestBuilders.delete("/schedules/delete/1"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.content().json("""
+                        { 
+                        "massage" : "delete success" 
+                        } 
+                        """));
+    }
 }
 


### PR DESCRIPTION
## deleteリクエストの結合テストを実装
下記の２つのテストを実装しました。
   1.deleteリクエストで指定したIDの予定情報を削除するテスト
8fbb796919ab04dd2957fd3a40e03f45bf54b9ea

   2.deleteリクエストで該当するIDが存在しない場合404を返すテスト
0ed28484e6c106f021d5499fffd987f04dd723d9

ご確認宜しくお願い致します。

### 動作確認結果です
<img width="1440" alt="スクリーンショット 2024-07-14 5 58 56" src="https://github.com/user-attachments/assets/77c4de13-2ee8-4b9e-865f-dcabf6ad0542">

